### PR TITLE
routed api docs page

### DIFF
--- a/articles/api_documentation.html
+++ b/articles/api_documentation.html
@@ -1,0 +1,62 @@
+---
+title: API Documentation
+layout: default
+---
+
+<div class="container">
+    <div class="row">
+        <div class="header" style="padding:150px 0 150px 0">
+            <div class="col-xs-12 col-sm-3">
+                <div class="action">
+                    <h3>
+                        <a href="http://docs.synapse.org/python">
+                            <img src="/assets/images/python_icon.jpeg" alt="python_icon" style="width: 2.0em;"/></a>
+                        <a href="http://docs.synapse.org/python">
+                            <br><br>Python Docs
+                            <h6><span class="subaction">Interact with Synapse using the Python Synapse client.</span></h6>
+                        </a>
+                    </h3>
+                </div>
+            </div>
+            <div class="col-xs-12 col-sm-3">
+                <div class="action">
+                    <h3>
+                        <a href="http://r-docs.synapse.org/">
+                            <img src="/assets/images/rstudio_icon.jpeg" alt="rstudio_icon" style="width: 2.0em;"/></a>
+                        <a href="http://r-docs.synapse.org/">
+                            <br><br>R Docs
+                            <h6><span class="subaction">Use the R client to interact with Synapse from scripts or interactive R sessions.</span></h6>
+                        </a>
+                    </h3>
+                </div>
+            </div>
+            <div class="col-xs-12 col-sm-3">
+                <div class="action">
+                    <h3>
+                        <a href="http://docs.synapse.org/python/CommandLineClient.html">
+                            <img src="/assets/images/bash_icon.png" alt="rstudio_icon" style="width: 2.5em;"/></a>
+                        <a href="http://docs.synapse.org/python/CommandLineClient.html">
+                            <br><br> Command Line
+                          <h6><span class="subaction">Connect and interact with Synpase directly using the Synapse command line client.</span></h6>
+                        </a>
+                    </h3>
+                </div>
+            </div>
+            <div class="col-xs-12 col-sm-3">
+                <div class="action">
+                    <h3>
+                        <a href="http://docs.synapse.org/rest">
+                            <img src="/assets/images/api_gears.png" alt="rstudio_icon" style="width: 2.0em;"/></a>
+                        <a href="http://docs.synapse.org/rest">
+                            <br><br>REST API
+                          <h6><span class="subaction">Build your own client using the Synapse REST APIs.</span></h6>
+                        </a>
+                    </h3>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ layout: default
       <div class="col-xs-12 col-sm-3">
         <div class="action">
           <h5>
-            <a href="/articles/api_docs.html">
+            <a href="/articles/api_documentation.html">
               <span class="glyphicon glyphicon-file"></span></br/>
                 API Docs<br/>
             <span class="subaction">Access language-specific functions for interacting with Synapse.</span>


### PR DESCRIPTION
was routing to the rest api docs page but now goes to a landing page with a selection of api docs