### PR TITLE
redirect accounts_certified_users_and_qualified_researchers.html to current page 

### DIFF
--- a/articles/accounts_certified_users_and_qualified_researchers.html
+++ b/articles/accounts_certified_users_and_qualified_researchers.html
@@ -4,7 +4,7 @@ layout: default
 ---
 
 <head>
-    <meta http-equiv="refresh" content="2; url=http://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html" />
+    <meta http-equiv="refresh" content="0; url=http://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html" />
     <title>redirect</title>
 </head>
 <body>

--- a/articles/accounts_certified_users_and_qualified_researchers.html
+++ b/articles/accounts_certified_users_and_qualified_researchers.html
@@ -1,0 +1,21 @@
+---
+title: redirect
+layout: default
+---
+
+<head>
+    <meta http-equiv="refresh" content="2; url=http://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html" />
+    <title>redirect</title>
+</head>
+<body>
+<div class="container" style="height: 400px">
+<h4 style="text-align: center">
+    If the page doesn't automatically redirect,
+    <br>
+    click <a href="accounts_certified_users_and_profile_validation.html">here</a>.
+    <br>
+    <br>
+    <img style="height: 200px;" src="/assets/images/stu-oops-sm.png"
+</h4>
+</div>
+</body>


### PR DESCRIPTION
Redirects any old links that are still called "accounts_certified_users_and_qualified_researchers.html" to the correct page "accounts_certified_users_and_profile_validation.html".
