### PR TITLE
reorder articles in governance tab

### DIFF
--- a/articles/access_controls.md
+++ b/articles/access_controls.md
@@ -3,6 +3,7 @@ title: "Sharing Settings and Conditions for Use"
 layout: article
 excerpt: Synapse has two content controls -- the Sharing setting and Conditions for Use. Learn how to set Sharing settings and Conditions for Use.
 category: governance
+order: 2
 ---
 
 <style>

--- a/articles/access_controls.md
+++ b/articles/access_controls.md
@@ -17,7 +17,7 @@ Synapse has two content controls: the `Sharing setting` and `Conditions for Use.
 
 <a name="sharing-setting"></a>
 
-# Sharing setting
+# Sharing settings
 You can use the `Sharing setting` to invite people to view or collaborate on a Synapse `Project`. There are two `Sharing settings`: **Public** and **Private**. Synapse content with the **Public** `Sharing setting` is visible to all Synapse users. By contrast, the **Private** `Sharing setting` limits who can see content. **By default, new `Projects` are Private.** 
 {% include important.html content="Synapse users are responsible for determining the appropriate Sharing Setting for any content they upload into Synapse." %}
 

--- a/articles/accounts_certified_users_and_profile_validation.md
+++ b/articles/accounts_certified_users_and_profile_validation.md
@@ -3,6 +3,7 @@ title: "User Types including Certified Users"
 layout: article
 excerpt: Find out about the three levels of Synapse users and the privileges and responsibilities associated with each level 
 category: governance
+order: 3
 ---
 
 <a name="synapse-user-credentials"></a>

--- a/articles/contribute_and_access_controlled_use_data.md
+++ b/articles/contribute_and_access_controlled_use_data.md
@@ -3,6 +3,7 @@ title: "Contribute and Access Controlled Data"
 layout: article
 excerpt: Learn how to contribute and access different types of Controlled Data.
 category: governance
+order: 4
 ---
 
 <a name="contributing-data"></a>

--- a/articles/governance.md
+++ b/articles/governance.md
@@ -3,6 +3,7 @@ title: Governance Overview
 layout: article
 excerpt: A look at the Synapse governance process.
 category: governance
+order: 1
 ---
 
 # Synapse Commons Governance Overview

--- a/articles/index.html
+++ b/articles/index.html
@@ -170,7 +170,8 @@ layout: default
                     <div class="tab-pane fade" id="governance"> <!--Start governance content-->
                         <h3 class="head text-center">Governance and Security</h3>
                         <div class="row">
-                            {% for page in site.pages %}
+                            {% assign sorted_pages = site.pages | sort:"order" %}
+                            {% for page in sorted_pages %}
                             {% if page.category == 'governance' %}
                             <div class="col-xs-12 col-sm-6 col-md-6">
                                 <div class="thumbnail"


### PR DESCRIPTION
1. Reordered articles under governance tab 
2. Corrected subheading "Sharing Setting" to "Sharing Settings" in Access Controls article