### PR TITLE
fixed security vulnerability in uglify-js by updating to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "reactify": "1.1.0",
     "superagent": "1.2.0",
     "through2": "0.6.3",
-    "uglify-js": "2.4.20",
+    "uglify-js": "2.6.0",
     "chance": "^1.0.3"
   },
   "scripts": {


### PR DESCRIPTION
Tested in local, new version doesn't seem to break anything.