### PR TITLE
clarify mirrorwiki vs copywiki

### DIFF
--- a/articles/challenge_administration.md
+++ b/articles/challenge_administration.md
@@ -174,9 +174,9 @@ Click on the Challenge Tab:
 
 ### 1 - Edit Challenge Wiki Privately
 
-Challenge organizers have found it convenient to author wiki pages privately, then publish the result when ready for public view.  Please review [steps A2](/articles/2---creating-dream-challenge-projects) for more information.  
+Challenge organizers have found it convenient to author wiki pages privately, then publish the result when ready for public view.  Please review [step A2](/articles/2---creating-dream-challenge-projects) for more information, and to learn how make the initial copy of the wiki from the staging site to the public site. 
 
-When you are pleased with your edits, please use the [mirrorWiki script](https://github.com/Sage-Bionetworks/DREAM-Utilities/blob/master/mirrorWiki.py) to mirror the staging site changes to the live site so that only changes are made on the staging site. 
+If significant modifications to the public wiki are required, you can first edit the staging project wiki to test your edits. Once you are satisfied with your wiki edits, you can use the [mirrorWiki script](https://github.com/Sage-Bionetworks/DREAM-Utilities/blob/master/mirrorWiki.py) to mirror the staging site changes to the live site so that only changes are made on the staging site. As mentioned above, for the initial copying of staging wiki content to the live site, please follow the instructions in [step A2](/articles/2---creating-dream-challenge-projects)
 
 {% include note.html content="The wiki titles are matched between the staging and live site, so if you don't want a page to be mirrored over, simply change the name of the wikipage." %}
 


### PR DESCRIPTION
I got a little confused when following this section and accidentally was using mirrorWiki.py instead of synapseutils copyWiki. I changed the language to make this a bit more evident.