### PR TITLE
Clarify updating annotations in R

### DIFF
--- a/articles/annotation_and_query.md
+++ b/articles/annotation_and_query.md
@@ -115,9 +115,6 @@ syn.store(entity, forceVersion = F)
 
 entity <- synGet("syn123")
 
-##### Modifying ONLY one annotation
-synSetAnnotation(entity, annotations=list(filType = "bam"))
-
 ##### Modifying a set of annotations
 synSetAnnotations(entity, annotations=list(fileType = "bam", assay = "RNA-seq"))
 

--- a/articles/annotation_and_query.md
+++ b/articles/annotation_and_query.md
@@ -116,6 +116,7 @@ syn.store(entity, forceVersion = F)
 entity <- synGet("syn123")
 
 ##### Modifying a set of annotations
+# Important note: this will REMOVE any other existing annotations
 synSetAnnotations(entity, annotations=list(fileType = "bam", assay = "RNA-seq"))
 
 		{%endhighlight %}

--- a/articles/annotation_and_query.md
+++ b/articles/annotation_and_query.md
@@ -115,8 +115,14 @@ syn.store(entity, forceVersion = F)
 
 entity <- synGet("syn123")
 
-##### Modifying a set of annotations
-# Important note: this will REMOVE any other existing annotations
+##### Modifying a set of annotations, preserving any existing annotations
+existing_annots <- synGetAnnotations(entity)
+synSetAnnotations(
+  entity,
+  annotations = c(existing_annots, list(fileType = "bam", assay = "rnaSeq"))
+)
+
+##### Add/update annotations, removing any other existing annotations
 synSetAnnotations(entity, annotations=list(fileType = "bam", assay = "RNA-seq"))
 
 		{%endhighlight %}


### PR DESCRIPTION
* Removes reference to `synSetAnnotation()` since this function doesn't exist
* Adds a warning that `synSetAnnotations()` removes existing annotations. This should probably be documented more thoroughly in the function itself in the python/R clients but I think it makes sense here too.