### PR TITLE
update setting CORS config on s3

### DIFF
--- a/articles/custom_storage_location.md
+++ b/articles/custom_storage_location.md
@@ -108,7 +108,7 @@ If you do not want to allow authorized Synapse users to upload data to your buck
 <br/>
 
 ### Make sure to enable cross-origin resource sharing (CORS)
-In **Properties**, click **Edit CORS configuration**. In the resulting pop-up, edit the configuration so that Synapse is included  in the `AllowedOrigin` tag. An example of CORS content that would allow this is:
+In **Permissions**, click **CORS configuration**. In the CORS configuration editor, edit the configuration so that Synapse is included  in the `AllowedOrigin` tag. An example CORS configuration that would allow this is:
 {% highlight html %}
 <CORSConfiguration>
     <CORSRule>


### PR DESCRIPTION
The UI for setting CORS on a custom s3 bucket is slightly different than the steps in the doc, just updating accordingly

Side concern: This doc suggests setting the CORS `Allowed-Origin` to `*`. Is this a security risk? If so, could we suggest something more secure/reasonable?