### PR TITLE
indicate importance of --acl flag when copying owner.txt file to bucket

### DIFF
--- a/articles/custom_storage_location.md
+++ b/articles/custom_storage_location.md
@@ -65,8 +65,8 @@ For **read-write** permissions, you also need to create an object that proves to
 
 {% tab AWScli %}
 {% highlight bash %}
-# copy your owner.txt file to your s3 bucket
-aws s3 cp owner.txt s3://nameofmybucket/nameofmyfolder
+# copy your owner.txt file to your s3 bucket with permission for synapse to read the file
+aws s3 cp owner.txt s3://nameofmybucket/nameofmyfolder --acl authenticated-read
 {% endhighlight %}
 {% endtab %}
 


### PR DESCRIPTION
When I copied the owner.txt file to my bucket without using the --acl flag, synapse was unable to read the file which resulted in an error.  