### PR TITLE
Fix example of updating a file in R

### DIFF
--- a/articles/files_and_versioning.md
+++ b/articles/files_and_versioning.md
@@ -185,10 +185,10 @@ library(synapser)
 file_to_update <- synGet('syn2222', downloadFile=FALSE)
 
 # save the local path to the new version of the file
-file_to_update$properties$path <- '/path/to/new/version/of/raw_data.txt'
+file_to_update$path <- '/path/to/new/version/of/raw_data.txt'
 
 # add a version comment
-file_to_update$properties$versionComment <- 'Added 5 random normally distributed numbers.'
+file_to_update$versionComment <- 'Added 5 random normally distributed numbers.'
 
 # store the new file
 updated_file <- synStore(file_to_update)


### PR DESCRIPTION
To set the path you need to use `file_to_update$path`. I also updated the example of setting a version comment, even though it doesn't work ([SYNR-1356](https://sagebionetworks.jira.com/browse/SYNR-1356)) so this example matches the [R client documentation](https://r-docs.synapse.org/articles/upload.html#uploading-a-new-version)