### PR TITLE
specify table of content header levels

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,8 @@ permalink: /:title
 highlighter: pygments
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
+
+toc:
+  min_level: 1 # default: 1
+  max_level: 4 # default: 6
+


### PR DESCRIPTION
So that we can use h5 for client name, and it won't make the toc longer than need be