### PR TITLE
Docker programmatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Images can be inserted using either Markdown or HTML, it all depends on your pre
 <img src="/assets/images/image1.jpg" alt="alt text">
 ```
 
+### Inserting code 
+The docs may contain a high level overview of a feature, but should link to the [Python docs](https://python-docs.synapse.org/build/html/index.html) and [synapser](https://r-docs.synapse.org/articles/synapser.html) docs, pointing to the relevant anchor, for code examples. This is to ensure code is validated with the client release cycles. 
+
 ## License
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/articles/docker.md
+++ b/articles/docker.md
@@ -9,6 +9,12 @@ Docker is a tool for creating, running, and managing lightweight virtual machine
 
 Synapse users interact with the Synapse Docker registry using the standard Docker client. In Synapse, Docker containers are represented as versioned 'repositories' under the 'Docker' tab. As with Files and Tables, Repositories are organized by project and inherit the access controls from the project.
 
+To learn more about working with Docker using one of our programmatic clients, including code examples for the below tasks, see:
+
+* Docker in [Python Docs](https://python-docs.synapse.org/build/html/Entity.html?highlight=docker#synapseclient.entity.DockerRepository).
+* Docker in [R Docs](https://r-docs.synapse.org/articles/docker.html).
+
+
 ## Creating a new Docker image
 
 Let's begin by creating a custom Docker image.  Users can choose to either modify an existing Docker image or build a Docker image from a Dockerfile.  Docker images must be tagged with 'docker.synapse.org/synapseProjectId/myreponame' to allow images to be saved.


### PR DESCRIPTION
closes #443.

I made a note in our README that code should primarily be documented in the client documentation, outside of Synapse docs.