### PR TITLE
Fix image link by removing typo of left curly brace

### DIFF
--- a/_articles/annotation_and_query.md
+++ b/_articles/annotation_and_query.md
@@ -11,7 +11,7 @@ category: metadata-and-annotations
 
  In this case, the annotations you may want to add might look like this:
 
-![Annotation example]({../assets/images/annotationsComplete.png)
+![Annotation example](../assets/images/annotationsComplete.png)
 
 ## Types of Annotations
 


### PR DESCRIPTION
Fixes #734. Image in Annotations and Queries as broken due to an extraneous curly brace. Removed.