### PR TITLE
fixes ordering of API clients

### DIFF
--- a/_articles/api_documentation.md
+++ b/_articles/api_documentation.md
@@ -4,6 +4,7 @@ description: Technical documentation for interacting with Synapse using R, Pytho
 excerpt: Technical documentation for interacting with Synapse using R, Python, command line, and the REST API.
 layout: index
 category: API-client
+order: 3
 ---
 
 


### PR DESCRIPTION
fixes #707

Getting started shows up at the top of the API Clients category/section