### PR TITLE
add shortcut to index

### DIFF
--- a/_articles/article_index.md
+++ b/_articles/article_index.md
@@ -1,7 +1,7 @@
 ---
-title: Articles Index
+title: Articles
 layout: index
-description: All documentation articles about Synapse.
+description: An index of articles available about Synapse.
 ---
 
 <div class="col-xs-12 col-md-12 col-lg-12" id="subjects">

--- a/_articles/index.md
+++ b/_articles/index.md
@@ -1,5 +1,5 @@
 ---
-title: Articles
+title: Overview
 layout: index
 description: These are the main instructions for using Synapse. Pick an section that interests you or read them in order.
 ---

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,7 +42,11 @@
                 <a href="{{'/articles/getting_started.html' | relative_url}}">Getting started</a>
             </li>
             <li>
-                <a href="{{'/articles/' | relative_url}}">Articles</a>
+                <a href="{{'/articles/' | relative_url}}">Overview</a>
+                
+            </li>
+            <li>
+                <a href="{{'/articles/article_index.html' | relative_url}}">Articles</a>
                 
             </li>
             <li>

--- a/index.md
+++ b/index.md
@@ -33,7 +33,7 @@ layout: index
     <div class="col-xs-12 col-md-6 col-lg-4">
         <a href="{{'articles/' | relative_url}}">
         <div class="subject-card">
-            <h5>Articles</h5>
+            <h5>Overview</h5>
             <hr>
             <span>Articles are categorized into topic areas describing the different components of Synapse and how to use them.</span>
         </div>


### PR DESCRIPTION
Fixes #716 

- Adds a shortcut in the header to the list of articles.
- Changes the verbiage from Articles to Overview and reserves "Articles" to describe the page listing all available articles. 
- Changed on all 4 levels of index pages.