### PR TITLE
Adding new category called Scientific Computing

### DIFF
--- a/_categories/scientific-computing.md
+++ b/_categories/scientific-computing.md
@@ -1,0 +1,8 @@
+---
+name: scientific-computing
+title: Scientific Computing
+excerpt: Computing on Synapse
+explanation: Computing resources can be created directly through Synapse
+section: additional-components
+order: 12
+---


### PR DESCRIPTION
This change adds a Jekyll category  for 'scientific computing' via resources generated through Synapse directly, namely through the service catalog attached to Synapse. Please review/comment on alternative ways to organize this!

- [x] Fixes #800 
- [ ] If you are creating a page, did you follow the instructions [here](https://github.com/Sage-Bionetworks/synapseDocs#creating-a-page)?
- [x] Did you follow the [style guide](https://github.com/Sage-Bionetworks/synapseDocs#style-guide)?
- [x] Did you include a description of your changes or additions in this pull request?
- [ ] (Optional) Did you examine your build locally (instructions [here](https://help.github.com/en/github/working-with-github-pages/))
