### PR TITLE
Adding initial Service Catalog acceptable use terms

### DIFF
--- a/_articles/sc-acceptable-use.md
+++ b/_articles/sc-acceptable-use.md
@@ -1,0 +1,51 @@
+---
+title: Synapse Scientific Computing Acceptable Use
+layout: article
+excerpt: Computing resources through Synapse requires agreement with appropriate use
+category: scientific-computing
+---
+
+By using the Synapse Service Catalog you take responsibility for the security of resources you create. Sage monitors the use of Service Catalog resources and the networks that connect them.
+
+You are individually responsible for the appropriate use of the resources you provision through the Service Catalog. You may not allow others to access the resources you create. You must not attempt to access restricted portions of the network or computing environment outside of what is provisioned specifically for you. You may not use access intended for others, and you may not use security testing tools or software designed to disrupt the computing environment.
+
+If your access is governed by a business agreement with a data contributor, you must abide by the terms of that agreement. If policies and guidelines conflict, the most restrictive requirement takes precedence.
+
+## Fair Share of Resources
+Sage expects  to maintain an acceptable level of performance for all users, and must assure that inappropriate use by some does not degrade performance for others. Sage may choose to set limits on an individual's use of a resource through quotas, time limits, etc. to ensure that these resources can be used by others.
+
+## Adherence with Federal, State, and Local Laws
+As a user of the Service Catalog you must abide by all local laws, and applicable copyright, licensing and intellectual property laws. If necessary for information security incident response purposes you may need to cooperate with law enforcement.
+
+## Other Inappropriate Activities
+Use of the Service Catalog must be consistent with the mission and business practices of Sage and partners. Prohibited activities include those that jeopardize Sage's reputation or those for political purposes or personal economic gain.
+
+You may use only the resources for which you are authorized, and authorized use is limited to the purpose for which the resource was created. Resources created through the Service Catalog may not be used for personal purposes, or for computing and storage other than what it was initially authorized. 
+## Software
+Computer users are expected to exercise careful judgement running software on any system that connects to Sage resources. Software, including source code, packages, libraries, dependencies, and apps should be downloaded from trusted repositories. Mobile code refers to software that can be delivered to an end point, like a virtual machine or web browser. All computer users are expected to exercise caution when purposefully running mobile code on hosts in Service Catalog.
+
+## Security Requirements for Working with Sensitive Information
+Information assets are classified into categories meant to clearly define the security requirements for handling the information on the asset and the asset in general. The use of an asset must be consistent with its classification. Sage uses the following schema for classifying contributed information:
+
+{:.markdown-table}
+| Controlled | This classification applies to data with specific regulatory, contractual, contributor, or consent terms. Controlled data includes protected health information (PHI). Access to controlled data is provisioned based on job roles with an explicit need for access. Computing with controlled data must follow established procedures and only be done on Service Catalog instances. |
+| Restricted | Restricted data may be accessed more generally than controlled data, but access is still limited to those with appropriate job roles. |
+| Public | Data explicitly classified as public may be accessed anonymously. There is no need to limit read access, but resources should not be made publicly writable. |
+
+The primary source of data, and any  authoritative copies of the data, are required to be housed in a dedicated environment. Secondary data, which by definition do not have the high availability requirements of primary data, may be processed in other environments as long as confidentiality and integrity objectives are satisfied. This means, for example, that primary data should be kept in Synapse while intermediate data should be handled through Service Catalog and uploaded to Synapse for longer term storage.
+
+## Compliance
+When you use Sage’s Service Catalog, you agree to comply with this agreement and Sage’s security policies. You are responsible for keeping up-to-date on changes on how we manage the computing environment and must adapt to those changes as necessary.
+
+Violations for noncompliance that have the potential to result in a security or privacy incident are recorded in a log for the purposes of identifying recurring issues resulting information security problems and to ensure that sanctions are applied fairly. 
+
+Sage refers to the following rubric to determine the appropriate course of action when handling a violation:
+
+{:.markdown-table}
+| Criteria | Low significance | High significance |
+| --- | --- | --- |
+| Intent | Accidental | Willful |
+| Recurrence | First occurance | Recurring violation |
+
+## Sage Bionetwork workforce
+If you work at Sage, our regular [Acceptable Use Policy](https://sites.google.com/sagebase.org/intranet/how-to/it) applies to any resources generated by the Service Catalog.


### PR DESCRIPTION
This PR adds the initial version of the acceptable use terms for users of the service catalog. 
Depends on https://github.com/Sage-Bionetworks/synapseDocs/pull/801

- [x] Fixes #800 
- [x] If you are creating a page, did you follow the instructions [here](https://github.com/Sage-Bionetworks/synapseDocs#creating-a-page)?
- [x] Did you follow the [style guide](https://github.com/Sage-Bionetworks/synapseDocs#style-guide)?
- [x] Did you include a description of your changes or additions in this pull request?
- [ ] (Optional) Did you examine your build locally (instructions [here](https://help.github.com/en/github/working-with-github-pages/))
