### PR TITLE
DOCS-22: Clarify DOI documentation, especially versions

### DIFF
--- a/_articles/doi.md
+++ b/_articles/doi.md
@@ -26,7 +26,11 @@ A Digital Object Identifier (DOI) is a persistent identifier assigned to uniquel
 
 DOIs are available in Synapse for Projects, Files, Folders, Tables, and Views. DOIs that are for objects stored in Synapse have a prefix of `doi:10.7303`. They are then followed by the Synapse ID of the object being linked to, such as `syn2580853`, which is a Synapse project. The DOI `doi:10.7303/syn2580853` can be represented as a URL, [https://doi.org/10.7303/syn2580853](https://doi.org/10.7303/syn2580853), which automatically redirects to the associated Synapse Project, the [AMP-AD Knowledge Portal](https://www.synapse.org/#!Synapse:syn2580853).  
 
-DOIs can be minted for specific versions of Files, Tables, and Views. When minting a DOI for a version, the synID and URL will have ".xx" appended to it, where "xx" indicates the version number (for example,  `10.7303/syn3539963.2`). If a new version is created, a new DOI will also need to be created to reference the new version.
+DOIs can be minted for specific versions of Files, Tables, and Views, which ensures that other researchers access the same data that you published, even if it's updated later. When minting a DOI for a version, the synID and URL will have ".xx" appended to it, where "xx" indicates the version number (for example,  `10.7303/syn3539963.2`). If a new version is created, a new DOI will also need to be created to reference the new version.
+
+If a DOI is minted without a version number, then the DOI will always link to the latest version of the object. This can be useful when referencing a living, changing document, where consistent access to the same set of data is less crucial.
+
+While DOIs are designed to be public, minting a DOI does not change the [Sharing Settings](sharing_settings.md) on an object. However, the metadata minted with a DOI, such as title and authors, will be retrievable from other sources, such as [CrossCite](https://citation.crosscite.org/), even if the object is private in Synapse.
 
 ## Minting DOIs
 
@@ -34,6 +38,4 @@ DOIs can be minted for specific versions of Files, Tables, and Views. When minti
 1. From the Tools Menu, select the option for "Create DOI" for the object in question, or choose "Create DOI" from the "Project Settings" menu if minting a DOI for an entire project.
 1. Fill out the form as needed - you can add other creators if there are other individuals who contributed to the object. You can select a resource type which describes what type of object it is. The title and publication year can be changed, but this is not advisable.
 
-If you do not see these options, you either do not have permission to do so. Only users with Edit access or above may mint DOIs for objects. You can also update an existing DOI if information has changed.
-
-
+If you do not see these options, you likely do not have permission to create a DOI for the object. Only users with Edit access or above may mint DOIs for objects. You can also update an existing DOI if information has changed.

--- a/_articles/files_and_versioning.md
+++ b/_articles/files_and_versioning.md
@@ -130,15 +130,15 @@ entity <- synDelete("syn56789")
 
 Versioning is an important component to reusable, reproducible research. When a Synapse `File` is initially uploaded, it automatically gets a version of `1`. It can be referred to explicitly by its Synapse ID: `syn12345678.1`. Uploading a new version of a file replaces the existing file in Synapse while preserving the previous version. The Synapse ID will remain but the version will increase, e.g., `syn12345678.2`. All versions are accessible through a single entry point (the Synapse ID, `syn12345678`). It is important to note that, by default, any previous versions of the file should still be available - they may be used in provenance relationships or as part of a data release. 
 
-Providing the Synapse ID without any versioning information to any of the clients (e.g., `syn12345678`) will always point to the most recent version of the file. In this way, updates to files can be automatically fetched by users by omitting the version.
+Providing the Synapse ID without any versioning information to any of the clients (e.g., `syn12345678`) will always point to the most recent version of the file. In this way, updates to files can be automatically fetched by users by omitting the version number.
 
-If a DOI has been created for a Synapse file, it is automatically versioned as well, so specific versions can be cited in other places.
+A DOI can be minted for an individual version of a `File`, so other researchers can easily access the same data that you published. For more information, see [DOIs](doi.md).
 
 The easiest way to create a new version of an existing Synapse `File` is to use the same file name and store it in the same location (e.g., the same `parentId`). Synapse will automatically determine that a new version of a file is being stored, only if the contents of the file have changed. If the contents have not changed (e.g., the `md5sum` of the file is identical to the most recent version), a new file will not be uploaded and the version will not increase.
 
 Only the file and annotations information are included in the version. Other metadata about a Synapse `File` (such as the description, name, parent, ACL, *and its associated Wiki*) are not part of the version, and will not change between versions.
 
-## Uploading a New Version
+### Uploading a New Version
 
 Uploading a new version follows the same steps as uploading a file for the first time - use the same file name and store it in the same location (e.g., the same `parentId`). **It is recommended to add a comment to the new version in order to easily track differences at a glance**. The example file `raw_data.txt` will now have a version of `2` and a comment describing the change.
 
@@ -208,7 +208,7 @@ synStore(File('path/to/old/raw_data.txt', parentId='syn123456'))
 new_file <- synStore(File('path/to/new_version/raw_data.txt',  parentId='syn123456'))
 ```
 
-## Updating Annotations or Provenance Without Changing Versions
+### Updating Annotations or Provenance Without Changing Versions
 
 Any change to a `File` will automatically update its version. If this isn't the desired behavior, such as minor cahnges to the metadata, you can set `forceVersion=False` with the Python or R clients. For command line, the commands `set-annotations` and `set-provenance` will update the metadata without creating a new version. Adding/updating annotations and provenance in the web client will also not cause a version change.
 
@@ -279,7 +279,7 @@ act <- Activity(name = 'Example Code', used = '/path/to/example_code')
 file <- synStore(file, activity=act, forceVersion=FALSE)
 ```
 
-## Downloading a Specific Version
+### Downloading a Specific Version
 
 By default, the `File` downloaded will always be the most recent version. However, a specific version can be downloaded by passing the `version` parameter.
 
@@ -306,7 +306,7 @@ entity = syn.get("syn56789", version=1)
 entity <- synGet("syn56789", version=1)
 ```
 
-## Deleting a Specific File Version
+### Deleting a Specific File Version
 
 A specific file version can be deleted by passing the `version` parameter.
 

--- a/_articles/tables.md
+++ b/_articles/tables.md
@@ -164,6 +164,11 @@ To list out the distinct treatent arms that were studied, by gender:
 SELECT GROUP_CONCAT(distinct(treatmentArm) SEPARATOR ', ') AS "Available Treatments", gender as "By Gender" FROM syn3079449 group by gender
 ```
 
+## Version a Table
+Versioning is an essential component of conducting reproducible research. Tables can be versioned to create a snapshot of your data at a specific point in time. This snapshot can then be referenced and shared.  For example, if you are collecting data in a Table, you may want to share your work with others for analysis. You can create a version to ensure that each collaborator sees the same data in the Table, even after adding data or changing data in the Table. Later, when you're ready for another data release, you can create a second version to share for additional analysis. At any time, you can refer back to previous versions to verify and reproduce your research.
+
+As you refine a Table, changes are saved to the synID (e.g. syn456). Unlike Files, which are automatically versioned anytime the file is changed, you decide when to manually create a Table version. Creating a new version adds a number to the parent synID (e.g. syn456.2), which can be used to reference or query that version within Synapse. Navigating to the parent synID (syn456) will always display the most recent changes to the Table, regardless of whether you have included them in a version. 
+
 # Using Table Facets
 
 The faceted navigation on `Tables` (also known as **simple search**) can be used to simplify your search without having to use SQL-like queries. Simple search uses radio buttons and sliders to show all available facets in a menu to the left of the `Table` whereas advanced search employs a SQL-like query to filter the `Table`. To use table facets, navigate to a `Table` or a `File View`. Simple and advanced search both allow you to query for features of interest in a`Table` using different methods.


### PR DESCRIPTION
- Fixes [DOCS-22](https://sagebionetworks.jira.com/browse/DOCS-22)
- Clarify information about DOIs
  - Versioning
  - Sharing settings
- Remove some incorrect information about DOIs and versions (minting a DOI does _not_ automatically create a new version)
- Document Table versions (I basically copy/pasted from Views and made some small adjustments)

Some content that I think we need to supplement this (probably tracked in new tickets):
- Which fields can be changed on the latest version of a file/table/view without creating a new version? What cannot?
  - What causes creating a new version via the Web, but can be done via Python/REST without creating a version?
- Which fields can be changed on "older versions"? What cannot? (Perhaps we need terminology to distinguish 'latest version' and 'all versions prior to the latest version')
- How do Sharing Settings affect Views?
  - e.g. we need to clarify that users won't see data in views if they don't have view permission on the entity referred to in the row. I think this is relevant to DOIs because you would want to know that users may see different data in a View based on their permissions.