### PR TITLE
[IT-1360] Remove user-guides.synapse.org CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-user-guides.synapse.org


### PR DESCRIPTION
This documentation repo is now deprecated, remove the Github Pages DNS entry.
