### PR TITLE
update example scripts for generating Synapse file handles from exter…

### DIFF
--- a/_articles/custom_storage_location.md
+++ b/_articles/custom_storage_location.md
@@ -257,7 +257,7 @@ fileHandle = {'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle'
               'storageLocationId': destination['storageLocationId']}
 fileHandle = syn.restPOST('/externalFileHandle/s3', json.dumps(fileHandle), endpoint=syn.fileHandleEndpoint)
 
-f = synapseclient.File(parentId=PROJECT, dataFileHandleId = fileHandle['id'])
+f = synapseclient.File(parentId=PROJECT, dataFileHandleId = fileHandle['id'], name=fileHandle['fileName'])
 
 f = syn.store(f)
 ```
@@ -276,7 +276,7 @@ fileHandle <- list(concreteType='org.sagebionetworks.repo.model.file.S3FileHandl
                    key ='s3ObjectKey')
 fileHandle <- synRestPOST('/externalFileHandle/s3', body=toJSON(fileHandle), endpoint = 'https://file-prod.prod.sagebase.org/file/v1')
 
-f <- File(dataFileHandleId=fileHandle$id, parentId=projectId)
+f <- File(dataFileHandleId=fileHandle$id, name=fileHandle$fileName, parentId=projectId)
 
 f <- synStore(f)
 ```


### PR DESCRIPTION
…nal S3 bucket


In the examples for creating Synapse file handles from an external S3 bucket ([https://help.synapse.org/docs/Custom-Storage-Locations.2048327803.html#CustomStorageLocations-AddingFilesinyourS3BuckettoSynapse](https://help.synapse.org/docs/Custom-Storage-Locations.2048327803.html#CustomStorageLocations-AddingFilesinyourS3BuckettoSynapse)), the resulting files on Synapse will be named with a Synapse ID rather than the fileName that is specified in the fileHandle dictionary. This PR updates the example scripts so that the resulting files on Synapse have the desired filenames. 